### PR TITLE
Give up computing transfer value as some fraction of available balances

### DIFF
--- a/Timetable.toml
+++ b/Timetable.toml
@@ -1,8 +1,8 @@
 scenarios = [
     { ident = "SimpleTransfer (7s)", interval = "7 seconds", scenario = { kind = "SimpleTransfer", transfer_value = 10 } },
     { ident = "RoundRobin (10s)", interval = "10 seconds", scenario = { kind = "RoundRobin", passes = 3, robin_value = 1 } },
-    { ident = "ManyToMany (10s)", interval = "10 seconds", scenario = { kind = "RandomTransfers", direction = "ManyToMany", granularity = "OneByOne", transfers = 5, transfer_fraction = 1 } },
-    { ident = "OneToMany (10s)", interval = "10 seconds", scenario = { kind = "RandomTransfers", direction = "OneToMany", granularity = "Batched", transfers = 7, transfer_fraction = 3 } },
+    { ident = "ManyToMany (10s)", interval = "10 seconds", scenario = { kind = "RandomTransfers", direction = "ManyToMany", granularity = "OneByOne", transfers = 5, transfer_value = 1 } },
+    { ident = "OneToMany (10s)", interval = "10 seconds", scenario = { kind = "RandomTransfers", direction = "OneToMany", granularity = "Batched", transfers = 7, transfer_value = 3 } },
     { ident = "Multisig (optimal)", interval = "12 seconds", scenario = { kind = "Multisig", party_size = { "Precise" = 4 }, threshold = { "Precise" = 3 }, strategy = "Optimal", cancel = false } },
     { ident = "Multisig (cancel)", interval = "15 seconds", scenario = { kind = "Multisig", party_size = "Large", threshold = { "Precise" = 3 }, strategy = "Optimal", cancel = true } },
     { ident = "VestingSchedulesMerging", interval = "60 seconds", scenario = { kind = "VestingSchedulesMerging" } },

--- a/scenarios/transfer/src/random_transfers.rs
+++ b/scenarios/transfer/src/random_transfers.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use aleph_client::{
-    get_free_balance, substrate_api_client, try_send_xt, AnyConnection, Connection, KeyPair,
-    SignedConnection,
+    substrate_api_client, try_send_xt, AnyConnection, Connection, KeyPair, SignedConnection,
 };
 use anyhow::Result as AnyResult;
 use codec::{Compact, Decode};
@@ -12,7 +11,7 @@ use substrate_api_client::{
     compose_call, compose_extrinsic, AccountId, GenericAddress, Pair, XtStatus,
 };
 
-use chain_support::{do_async, keypair_derived_from_seed, with_event_listening, Event};
+use chain_support::{keypair_derived_from_seed, real_amount, with_event_listening, Event};
 use common::{Scenario, ScenarioError, ScenarioLogging};
 
 use crate::try_transfer;
@@ -74,11 +73,8 @@ pub struct RandomTransfers {
     /// E.g. in `OneToMany`, `transfers` will determine how many receivers
     /// are there.
     transfers: usize,
-    /// To avoid exhausting one's balances, senders in these scenarios
-    /// transfer a constant fraction of their balances. `transfer_fraction`
-    /// describes this part in thousandths (passing e.g. 5 will result in
-    /// sending 0.5% of available funds).
-    transfer_fraction: u16,
+    /// How many tokens should be transferred (in a single transfer).
+    transfer_value: u64,
 }
 
 /// Represents a single sender-receiver pair.
@@ -139,24 +135,6 @@ impl RandomTransfers {
             .collect()
     }
 
-    /// Computes estimated fraction of `balances` (`self.transfer_fraction`‰).
-    fn balances_fraction(&self, balances: u128) -> u128 {
-        balances
-            .saturating_div(1000)
-            .saturating_mul(self.transfer_fraction as u128)
-    }
-
-    /// Computes how much money should be transferred from `sender`.
-    async fn compute_transfer_value(
-        &self,
-        connection: &Connection,
-        sender: &KeyPair,
-    ) -> AnyResult<u128> {
-        let sender_account = AccountId::from(sender.public());
-        let sender_balances = do_async!(get_free_balance, &connection, &sender_account)?;
-        Ok(self.balances_fraction(sender_balances))
-    }
-
     async fn send_sequentially(
         &self,
         connection: &Connection,
@@ -176,9 +154,13 @@ impl RandomTransfers {
                 sender_id, receiver_id
             ));
 
-            let transfer_value = self.compute_transfer_value(connection, &sender).await?;
-            let transfer_result =
-                try_transfer(connection, &sender, &receiver, transfer_value).await;
+            let transfer_result = try_transfer(
+                connection,
+                &sender,
+                &receiver,
+                real_amount(&self.transfer_value),
+            )
+            .await;
             logger.log_result(transfer_result)?;
 
             logger.debug(format!(
@@ -212,7 +194,6 @@ impl RandomTransfers {
                 sender_id, receiver_id
             ));
 
-            let transfer_value = self.compute_transfer_value(connection, &sender).await?;
             let metadata = SignedConnection::from_any_connection(connection, sender)
                 .as_connection()
                 .metadata;
@@ -221,7 +202,7 @@ impl RandomTransfers {
                 "Balances",
                 "transfer",
                 GenericAddress::Id(receiver),
-                Compact(transfer_value)
+                Compact(real_amount(&self.transfer_value))
             ));
         }
 


### PR DESCRIPTION
Until now, `RandomTransfers` scenario expected `transfer_fraction` parameter which decided what thousandth of free balances should be sent. We give it up for several reasons:
 - for `n` senders it requires `n` separate storage reads, which significantly increases scenario run time
 - tbh, it is overkill
 - it is inconsistent with other transfer-related scnearios