### PR TITLE
Add proxy for logs route

### DIFF
--- a/docker/frontend/traffic-maker.site
+++ b/docker/frontend/traffic-maker.site
@@ -15,6 +15,10 @@ server {
     proxy_pass http://backend:8080;
   }
 
+  location /logs {
+    proxy_pass http://backend:8080;
+  }
+
   location ~ /(images|js|css|fonts|resources)(.*)$ {
     expires 1h;
     add_header Cache-Control "public";


### PR DESCRIPTION
Last time we forgot about `/logs/...` route (apart from `/details` :(