### PR TITLE
Read base seed in runtime

### DIFF
--- a/chain-support/src/lib.rs
+++ b/chain-support/src/lib.rs
@@ -1,7 +1,7 @@
 // Needed for `do_async!`.
 #![feature(fn_traits)]
 
-use std::fmt::Display;
+use std::{env, fmt::Display};
 
 pub use aleph_client::{
     create_connection, keypair_from_string, send_xt, try_send_xt, AnyConnection, Connection,
@@ -21,7 +21,7 @@ mod macros;
 /// The base seed is empty by default, but can be overridden with env `SECRET_PHRASE_SEED`.
 /// Assumes that `seed` is already prefixed with a derivation delimiter (either `/` or `//`).
 pub fn keypair_derived_from_seed<S: AsRef<str> + Display>(seed: S) -> KeyPair {
-    let base_seed = option_env!("SECRET_PHRASE_SEED").unwrap_or("");
+    let base_seed = env::var("SECRET_PHRASE_SEED").unwrap_or_default();
     let full_seed = format!("{}{}", base_seed, seed);
     keypair_from_string(&*full_seed)
 }

--- a/set_up/Cargo.lock
+++ b/set_up/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "log",
+ "parse_duration",
  "serde",
  "thiserror",
 ]
@@ -1443,7 +1444,7 @@ dependencies = [
  "approx",
  "matrixmultiply",
  "nalgebra-macros",
- "num-complex",
+ "num-complex 0.4.1",
  "num-rational 0.4.0",
  "num-traits",
  "rand 0.8.5",
@@ -1481,6 +1482,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex 0.2.4",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1503,16 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
  "num-traits",
 ]
 
@@ -1517,6 +1542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1881,6 +1917,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys",
+]
+
+[[package]]
+name = "parse_duration"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
+dependencies = [
+ "lazy_static",
+ "num",
+ "regex",
 ]
 
 [[package]]
@@ -2424,7 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e82063457853d00243beda9952e910b82593e4b07ae9f721b9278a99a0d3d5c"
 dependencies = [
  "approx",
- "num-complex",
+ "num-complex 0.4.1",
  "num-traits",
  "paste",
 ]


### PR DESCRIPTION
Previously we were reading `SECRET_PHRASE_SEED` during compilation time which effectively prevented us to inject secret in after deployment. Now it is possible to provide it after binary is built.